### PR TITLE
Linting and Formatting

### DIFF
--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -476,8 +476,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
     elif 1 + 2 * num_harmonics > x0.shape[1]:
         x_freq = fftp.fft(x0)
         x_zeros = np.zeros((x0.shape[0], 1 + num_harmonics * 2 - x0.shape[1]))
-        x_freq = np.insert(x_freq, [x0.shape[1] - x0.shape[1] // 2], x_zeros,
-                           axis=1)
+        x_freq = np.insert(x_freq, [x0.shape[1] - x0.shape[1] // 2], x_zeros, axis=1)
 
         x0 = fftp.ifft(x_freq) * (1 + num_harmonics * 2) / x0.shape[1]
         x0 = np.real(x0)

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -179,7 +179,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         x0 = np.real(x0)
     if isinstance(sdfunc, str):
         sdfunc = globals()[sdfunc]
-        print("sdfunc is expected to be a function name, not a string")
+        print('sdfunc is expected to be a function name, not a string')
     params['function'] = sdfunc  # function that returns SO derivative
     time = np.linspace(0, 2 * np.pi / omega, num=x0.shape[1], endpoint=False)
     params['time'] = time
@@ -277,7 +277,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
             e = vel_from_deriv - vel
         else:
-            print('eqform cannot have a value of {}', eqform)
+            print(f'eqform cannot have a value of {eqform}')
             return 0, 0, 0, 0, 0
         return e
 
@@ -471,7 +471,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         x0 = np.real(x0)
     if isinstance(sdfunc, str):
         sdfunc = globals()[sdfunc]
-        print("sdfunc is expected to be a function name, not a string")
+        print('sdfunc is expected to be a function name, not a string')
     params['function'] = sdfunc  # function that returns SO derivative
     time = np.linspace(0, 2 * np.pi / omega, num=x0.shape[1], endpoint=False)
     params['time'] = time
@@ -590,7 +590,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
             states = vel
         else:
-            print('eqform cannot have a value of {}', eqform)
+            print(f'eqform cannot have a value of {eqform}')
             return 0, 0, 0, 0, 0
 
         states_fft = fftp.rfft(states)
@@ -616,7 +616,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         phases = np.arctan2(X[:, 1], -X[:, 2])
     except Exception as exception:  # Catches and raises errors- needs actual error listed.
         print('Excepted- search failed for omega = {:6.4f} rad/s.'.format(omega))
-        print('What ever error this is, please put into har_bal after the excepts (2 of them)')
+        print('Whatever error this is, please put into har_bal after the excepts (2 of them)')
         X = X0
         print(mask_constant)
         e = hb_err(X)
@@ -1021,8 +1021,7 @@ def mousai_to_solve_ivp(sdfunc, params):
 
     if len(call_parameters) == 2:
         sdfunc = old_mousai_to_new_mousai(sdfunc)
-        print("""Warning. The two-argument form of Mousai derivsative functions
-                 is deprecated.""")
+        print('Warning. The two-argument form of Mousai derivsative functions is deprecated.')
 
     def solve_ivp_function(t, y):
         return sdfunc(y, t, params)
@@ -1060,10 +1059,10 @@ def mousai_to_odeint(sdfunc, params):
 
     if len(call_parameters) == 2:
         sdfunc = old_mousai_to_new_mousai(sdfunc)
-        print("""Warning. The two-argument form of Mousai derivative ⁠⁠functions is deprecated.""")
+        print('Warning. The two-argument form of Mousai derivative ⁠⁠functions is deprecated.')
 
     if 'sdfunc_params' not in globals():
-        print("Define your parameters in the user created `sdfunc_params`", "dictionary.")
+        print('Define your parameters in the user created `sdfunc_params` dictionary.')
         sdfunc_params = {}
 
     def odeint_function(y, t):

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -816,8 +816,10 @@ def expand_rfft(X, num_harmonics):
 
     X_len = X.shape[1]
     cur_num_harmonics = (X_len - 1) / 2
-    X_expanded = np.hstack((X / X_len * (1 + 2 * num_harmonics), np.zeros((X.shape[0], int(2 * (num_harmonics - cur_num_harmonics))))))
-    return X_expanded
+    data_type = int(2 * (num_harmonics - cur_num_harmonics))
+    empty_array = np.zeros((X.shape[0], data_type))
+    data = X / X_len * (1 + 2 * num_harmonics)
+    return np.hstack((data, empty_array))
 
 
 def rfft_to_fft(X_real):

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -1,14 +1,14 @@
 """Harmonic balance solvers and other related tools."""
+import inspect
 import warnings
+
 # import logging
 import numpy as np
 import scipy as sp
 import scipy.fftpack as fftp
 import scipy.linalg as la
-import inspect
-from scipy.optimize import newton_krylov, anderson, broyden1, broyden2, \
-    excitingmixing, linearmixing, diagbroyden
-
+from scipy.optimize import (anderson, broyden1, broyden2, diagbroyden,
+                            excitingmixing, linearmixing, newton_krylov)
 
 # logging.basicConfig(level=print)
 # Use `logging.debug` in place of print.

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -565,9 +565,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
         x = fftp.irfft(X)
         time_e, x = time_history(time, x, num_time_points=num_time_steps)
-
         vel = harmonic_deriv(omega, x)
-
         m = num_time_steps
 
         if eqform == 'second_order':
@@ -588,7 +586,6 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
             states = accel
 
         elif eqform == 'first_order':
-
             vel_from_deriv = np.zeros_like(vel)
             # Should subtract in place below to save memory for large problems
             for i in np.arange(m):
@@ -598,20 +595,15 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 # Note that everything in params can be accessed within
                 # `function`.
                 vel_from_deriv[:, i] = params['function'](x[:, i], params)[:, 0]
-
             e = (vel_from_deriv - vel)  # /np.max(np.abs(vel))
-
             states = vel
         else:
             print(f'eqform cannot have a value of {eqform}')
             return 0, 0, 0, 0, 0
 
         states_fft = fftp.rfft(states)
-
         e_fft = fftp.rfft(e)
-
         states_fft_condensed = condense_rfft(states_fft, num_harmonics)
-
         e = condense_rfft(e_fft, num_harmonics)
 
         if mask_constant:
@@ -627,6 +619,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
             X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
         amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
         phases = np.arctan2(X[:, 1], -X[:, 2])
+
     except Exception as exception:  # Catches and raises errors- needs actual error listed.
         print('Excepted- search failed for omega = {:6.4f} rad/s.'.format(omega))
         print('Whatever error this is, please put into har_bal after the excepts (2 of them)')
@@ -637,7 +630,6 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
             X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
         amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
         phases = np.arctan2(X[:, 1], -X[:, 2])
-
         raise
 
     x = fftp.irfft(X)

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -783,8 +783,8 @@ def time_history(t, x, num_time_points=200, realify=True):
     x_freq = fftp.fft(x)
     x_zeros = np.zeros((x.shape[0], t.size - x.shape[1]))
     x_freq = np.insert(x_freq, [t_length - t_length // 2], x_zeros, axis=1)
-
     x = fftp.ifft(x_freq) * num_time_points / t_length
+
     if realify:
         x = np.real(x)
     else:

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -4,11 +4,8 @@ import warnings
 
 # import logging
 import numpy as np
-import scipy as sp
 import scipy.fftpack as fftp
 import scipy.linalg as la
-from scipy.optimize import (anderson, broyden1, broyden2, diagbroyden,
-                            excitingmixing, linearmixing, newton_krylov)
 
 # logging.basicConfig(level=print)
 # Use `logging.debug` in place of print.

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -254,6 +254,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         time = params['time']
         m = 1 + 2 * n_har
         vel = harmonic_deriv(omega, x)
+
         if eqform == 'second_order':
             accel = harmonic_deriv(omega, vel)
             accel_from_deriv = np.zeros_like(accel)
@@ -268,8 +269,10 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 # `function`.
                 accel_from_deriv[:, i] = params['function'](x[:, i], vel[:, i], params)[:, 0]
             e = accel_from_deriv - accel
+
         elif eqform == 'first_order':
             vel_from_deriv = np.zeros_like(vel)
+
             # Should subtract in place below to save memory for large problems
             for i in np.arange(m):
                 # This should enable t to be used for current time in loops
@@ -280,6 +283,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 vel_from_deriv[:, i] = params['function'](x[:, i], params)[:, 0]
 
             e = vel_from_deriv - vel
+
         else:
             print(f'eqform cannot have a value of {eqform}')
             return 0, 0, 0, 0, 0
@@ -287,12 +291,14 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
     try:
         x = globals()[method](hb_err, x0, **kwargs)
+
     except Exception as exception:
         x = x0  # np.full([x0.shape[0],x0.shape[1]],np.nan)
         amps = np.full([x0.shape[0], ], np.nan)
         phases = np.full([x0.shape[0], ], np.nan)
         e = hb_err(x)  # np.full([x0.shape[0],x0.shape[1]],np.nan)
         raise
+
     else:
         xhar = fftp.fft(x) * 2 / len(time)
         amps = np.absolute(xhar[:, 1])

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -166,16 +166,14 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         if num_variables is not None:
             x0 = np.zeros((num_variables, 1 + num_harmonics * 2))
         else:
-            print('Error: Must either define number of variables or initial\
-                  guess for x.')
+            print('Error: Must either define number of variables or initial guess for x.')
             return
     elif num_harmonics is None:
         num_harmonics = int((x0.shape[1] - 1) / 2)
     elif 1 + 2 * num_harmonics > x0.shape[1]:
         x_freq = fftp.fft(x0)
         x_zeros = np.zeros((x0.shape[0], 1 + num_harmonics * 2 - x0.shape[1]))
-        x_freq = np.insert(x_freq, [x0.shape[1] - x0.shape[1] // 2], x_zeros,
-                           axis=1)
+        x_freq = np.insert(x_freq, [x0.shape[1] - x0.shape[1] // 2], x_zeros, axis=1)
 
         x0 = fftp.ifft(x_freq) * (1 + num_harmonics * 2) / x0.shape[1]
         x0 = np.real(x0)
@@ -586,8 +584,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 params['cur_time'] = time_e[i]
                 # Note that everything in params can be accessed within
                 # `function`.
-                vel_from_deriv[:, i] =\
-                    params['function'](x[:, i], params)[:, 0]
+                vel_from_deriv[:, i] = params['function'](x[:, i], params)[:, 0]
 
             e = (vel_from_deriv - vel)  # /np.max(np.abs(vel))
 
@@ -794,9 +791,7 @@ def time_history(t, x, num_time_points=200, realify=True):
 def condense_fft(X_full, num_harmonics):
     """Create equivalent amplitude reduced-size FFT from longer FFT."""
 
-    X_red = (np.hstack((X_full[:, 0:(num_harmonics + 1)],
-                        X_full[:, -1:-(num_harmonics + 1):-1]))
-             * (2 * num_harmonics + 1) / X_full[0, :].size)
+    X_red = (np.hstack((X_full[:, 0:(num_harmonics + 1)], X_full[:, -1:-(num_harmonics + 1):-1])) * (2 * num_harmonics + 1) / X_full[0, :].size)
     return X_red
 
 
@@ -804,8 +799,7 @@ def condense_rfft(X_full, num_harmonics):
     """Return real fft with fewer harmonics."""
 
     X_len = X_full.shape[1]
-    X_red = X_full[:, :(num_harmonics) * 2 + 1] / \
-        X_len * (1 + 2 * num_harmonics)
+    X_red = X_full[:, :(num_harmonics) * 2 + 1] / X_len * (1 + 2 * num_harmonics)
     return X_red
 
 
@@ -814,11 +808,7 @@ def expand_rfft(X, num_harmonics):
 
     X_len = X.shape[1]
     cur_num_harmonics = (X_len - 1) / 2
-    X_expanded = np.hstack((X / X_len * (1 + 2 * num_harmonics),
-                            np.zeros((X.shape[0],
-                                      int(2 * (num_harmonics
-                                               - cur_num_harmonics))))
-                            ))
+    X_expanded = np.hstack((X / X_len * (1 + 2 * num_harmonics), np.zeros((X.shape[0], int(2 * (num_harmonics - cur_num_harmonics))))))
     return X_expanded
 
 
@@ -1070,12 +1060,10 @@ def mousai_to_odeint(sdfunc, params):
 
     if len(call_parameters) == 2:
         sdfunc = old_mousai_to_new_mousai(sdfunc)
-        print("""Warning. The two-argument form of Mousai derivative ⁠⁠\
-                 functions is deprecated.""")
+        print("""Warning. The two-argument form of Mousai derivative ⁠⁠functions is deprecated.""")
 
     if 'sdfunc_params' not in globals():
-        print("Define your parameters in the user created `sdfunc_params`",
-              "dictionary.")
+        print("Define your parameters in the user created `sdfunc_params`", "dictionary.")
         sdfunc_params = {}
 
     def odeint_function(y, t):

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -469,8 +469,10 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         else:
             print('Error: Must either define number of variables or initial guess for x.')
             return
+
     elif num_harmonics is None:
         num_harmonics = int((x0.shape[1] - 1) / 2)
+
     elif 1 + 2 * num_harmonics > x0.shape[1]:
         x_freq = fftp.fft(x0)
         x_zeros = np.zeros((x0.shape[0], 1 + num_harmonics * 2 - x0.shape[1]))
@@ -482,6 +484,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
     if isinstance(sdfunc, str):
         sdfunc = globals()[sdfunc]
         print('sdfunc is expected to be a function name, not a string')
+
     params['function'] = sdfunc  # function that returns SO derivative
     time = np.linspace(0, 2 * np.pi / omega, num=x0.shape[1], endpoint=False)
     params['time'] = time

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -596,6 +596,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 vel_from_deriv[:, i] = params['function'](x[:, i], params)[:, 0]
             e = (vel_from_deriv - vel)  # /np.max(np.abs(vel))
             states = vel
+
         else:
             print(f'eqform cannot have a value of {eqform}')
             return 0, 0, 0, 0, 0

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -816,6 +816,7 @@ def expand_rfft(X, num_harmonics):
 
     X_len = X.shape[1]
     cur_num_harmonics = (X_len - 1) / 2
+    # TODO: rename below vars. Were pulled from last line to improve readability
     data_type = int(2 * (num_harmonics - cur_num_harmonics))
     empty_array = np.zeros((X.shape[0], data_type))
     data = X / X_len * (1 + 2 * num_harmonics)
@@ -938,7 +939,7 @@ def function_to_mousai(sdfunc):
     call_parameters = list(sig.parameters.keys())
 
     if len(call_parameters) == 2:
-        if call_parameters[0] == 't' or call_parameters[0] == 'time':
+        if call_parameters[0].lower() in {'t', 'time'}:
             # t and x must be swapped, params available in over-scope
             def newfunction(x, t, params={}):
                 for k, v in params.items():
@@ -951,7 +952,7 @@ def function_to_mousai(sdfunc):
                 return sdfunc(x, t)
 
     else:
-        if call_parameters[0] == 't' or call_parameters[0] == 'time':
+        if call_parameters[0].lower() in {'t', 'time'}:
             # t and x must be swapped, params available in over-scope
             def newfunction(x, t, params={}):
                 other_params = [params[x] for x in call_parameters]

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -159,8 +159,8 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
     Options to the nonlinear solvers can be passed in by \*\*kwargs (keyword
     arguments) identical to those available to the nonlinear solver.
-
     """
+
     # Initial conditions exist?
     if x0 is None:
         if num_variables is not None:
@@ -244,8 +244,8 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
             4. The difference between `accel_num` and `accel` or
                `velocity_num` and `velocity` represent the error used
                by the numerical algebraic equation solver.
-
         """
+
         nonlocal params  # Will stay out of global/conflicts
         n_har = params['n_har']
         omega = params['omega']
@@ -451,8 +451,8 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
            (default `newton_krylov`) to be minimized by the solver.
 
     Options to the nonlinear solvers can be passed in by \*\*kwargs.
-
     """
+
     # Initial conditions exist?
     if x0 is None:
         if num_variables is not None:
@@ -487,64 +487,64 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
     params['mask_constant'] = mask_constant
 
     def hb_err(X):
-        """Return errors in equation eval versus derivative calculation."""
-        # r"""Array (vector) of hamonic balance second order algebraic errors.
-        #
-        # Given a set of second order equations
-        # :math:`\ddot{x} = f(x, \dot{x}, \omega, t)`
-        # calculate the error :math:`E = \mathcal{F}(\ddot{x}
-        # - \mathcal{F}\left(f(x, \dot{x}, \omega, t)\right)`
-        # presuming that :math:`x` can be represented as a Fourier series, and
-        # thus :math:`\dot{x}` and :math:`\ddot{x}` can be obtained from the
-        # Fourier series representation of :math:`x` and :math:`\mathcal{F}(x)`
-        # represents the Fourier series of :math:`x(t)`
-        #
-        # Parameters
-        # ----------
-        # X : float array
-        #     X is an :math:`n \\times m` by 1 array of sp.fft.rfft
-        #     fft coefficients lacking the constant (first) element.
-        #     Here :math:`n` is the number of displacements and :math:`m` 2
-        #     times the number of harmonics to be solved for.
-        #
-        # **kwargs : string, float, variable
-        #     **kwargs is a packed set of keyword arguments with 3 required
-        #     arguments.
-        #         1. `function`: a string name of the function which returned
-        #         the numerically calculated acceleration.
-        #
-        #         2. `omega`: which is the defined fundamental harmonic
-        #         at which the is desired.
-        #
-        #         3. `n_har`: an integer representing the number of harmonics.
-        #         Note that `m` above is equal to 2 * `n_har`.
-        #
-        # Returns
-        # -------
-        # e : float array
-        #     2d array of numerical errors of presumed solution(s) `X`. Error
-        #     between first (or second) derivative via Fourier analysis and via
-        #     solution of the governing equation.
-        #
-        # Notes
-        # -----
-        # `function` and `omega` are not separately defined arguments so as to
-        # enable algebraic solver functions to call `hb_err` cleanly.
-        #
-        # The algorithm is as follows:
-        #     1. X is prepended with a zero vector (to represent the constant
-        #        value)
-        #     2. `x` is calculated via an inverse `numpy.fft.rfft`
-        #     1. The velocity and accelerations are calculated in the same
-        #        shape as `x` as `vel` and `accel`.
-        #     3. Each column of `x` and `v` are sent with `t`, `omega`, and
-        #        other `**kwargs** to `function` one at a time with the results
-        #        agregated into the columns of `accel_num`.
-        #     4. The rfft is taken of `accel_num` and `accel`.
-        #     5. The first column is stripped out of both `accel_num_freq and
-        #        `accel_freq`.
+        r"""Return errors in equation eval versus derivative calculation.
+        Array (vector) of hamonic balance second order algebraic errors.
 
-        # """
+        Given a set of second order equations
+        :math:`\ddot{x} = f(x, \dot{x}, \omega, t)`
+        calculate the error :math:`E = \mathcal{F}(\ddot{x}
+        - \mathcal{F}\left(f(x, \dot{x}, \omega, t)\right)`
+        presuming that :math:`x` can be represented as a Fourier series, and
+        thus :math:`\dot{x}` and :math:`\ddot{x}` can be obtained from the
+        Fourier series representation of :math:`x` and :math:`\mathcal{F}(x)`
+        represents the Fourier series of :math:`x(t)`
+
+        Parameters
+        ----------
+        X : float array
+            X is an :math:`n \\times m` by 1 array of sp.fft.rfft
+            fft coefficients lacking the constant (first) element.
+            Here :math:`n` is the number of displacements and :math:`m` 2
+            times the number of harmonics to be solved for.
+
+        **kwargs : string, float, variable
+            **kwargs is a packed set of keyword arguments with 3 required
+            arguments.
+                1. `function`: a string name of the function which returned
+                the numerically calculated acceleration.
+
+                2. `omega`: which is the defined fundamental harmonic
+                at which the is desired.
+
+                3. `n_har`: an integer representing the number of harmonics.
+                Note that `m` above is equal to 2 * `n_har`.
+
+        Returns
+        -------
+        e : float array
+            2d array of numerical errors of presumed solution(s) `X`. Error
+            between first (or second) derivative via Fourier analysis and via
+            solution of the governing equation.
+
+        Notes
+        -----
+        `function` and `omega` are not separately defined arguments so as to
+        enable algebraic solver functions to call `hb_err` cleanly.
+
+        The algorithm is as follows:
+            1. X is prepended with a zero vector (to represent the constant
+               value)
+            2. `x` is calculated via an inverse `numpy.fft.rfft`
+            1. The velocity and accelerations are calculated in the same
+               shape as `x` as `vel` and `accel`.
+            3. Each column of `x` and `v` are sent with `t`, `omega`, and
+               other `**kwargs** to `function` one at a time with the results
+               agregated into the columns of `accel_num`.
+            4. The rfft is taken of `accel_num` and `accel`.
+            5. The first column is stripped out of both `accel_num_freq and
+               `accel_freq`.
+        """
+
         nonlocal params  # Will stay out of global/conflicts
         omega = params['omega']
         time = params['time']
@@ -680,8 +680,8 @@ def harmonic_deriv(omega, r):
     >>> state_derives = harmonic_deriv(omega,states)
     >>> plt.plot(t,states.T,t,state_derives.T,'x')
     [<matplotlib.line...]
-
     """
+
     s = np.zeros_like(r)
     for i in np.arange(r.shape[0]):
         s[i, :] = fftp.diff(r[i, :]) * omega
@@ -716,13 +716,14 @@ def solmf(x, v, M, C, K, F):
     >>> print(a)
         [[-0.95]
          [ 1.6 ]]
-
     """
+
     return -la.solve(M, C @ v + K @ x - F)
 
 
 def duff_osc(x, v, params):
     """Duffing oscillator acceleration."""
+
     omega = params['omega']
     t = params['cur_time']
     acceleration = np.array([[-x - .1 * x**3. - 0.2 * v + np.sin(omega * t)]])
@@ -773,8 +774,8 @@ def time_history(t, x, num_time_points=200, realify=True):
     made when setting up the harmonic balance solution. Whether this is a valid
     assumption is something that the user must judge when obtaining the
     solution.
-
     """
+
     dt = t[1]
     t_length = t.size
     t = np.linspace(0, t_length * dt, num_time_points, endpoint=False)
@@ -792,6 +793,7 @@ def time_history(t, x, num_time_points=200, realify=True):
 
 def condense_fft(X_full, num_harmonics):
     """Create equivalent amplitude reduced-size FFT from longer FFT."""
+
     X_red = (np.hstack((X_full[:, 0:(num_harmonics + 1)],
                         X_full[:, -1:-(num_harmonics + 1):-1]))
              * (2 * num_harmonics + 1) / X_full[0, :].size)
@@ -800,6 +802,7 @@ def condense_fft(X_full, num_harmonics):
 
 def condense_rfft(X_full, num_harmonics):
     """Return real fft with fewer harmonics."""
+
     X_len = X_full.shape[1]
     X_red = X_full[:, :(num_harmonics) * 2 + 1] / \
         X_len * (1 + 2 * num_harmonics)
@@ -808,6 +811,7 @@ def condense_rfft(X_full, num_harmonics):
 
 def expand_rfft(X, num_harmonics):
     """Return real fft with mor harmonics."""
+
     X_len = X.shape[1]
     cur_num_harmonics = (X_len - 1) / 2
     X_expanded = np.hstack((X / X_len * (1 + 2 * num_harmonics),
@@ -820,12 +824,14 @@ def expand_rfft(X, num_harmonics):
 
 def rfft_to_fft(X_real):
     """Switch from SciPy real fft form to complex fft form."""
+
     X = fftp.fft(fftp.irfft(X_real))
     return X
 
 
 def fft_to_rfft(X):
     """Switch from complex form fft form to SciPy rfft form."""
+
     X_real = fftp.rfft(np.real(fftp.ifft(X)))
     return X_real
 
@@ -874,8 +880,8 @@ def time_history_r(t, x, num_time_points=200, realify=True):
     made when setting up the harmonic balance solution. Whether this is a valid
     assumption is something that the user must judge when obtaining the
     solution.
-
     """
+
     dt = t[1]
     t_length = t.size
     t = np.linspace(0, t_length * dt, num_time_points, endpoint=False)
@@ -983,8 +989,8 @@ def old_mousai_to_new_mousai(function):
        * ``function_to_mousai``
        * ``mousai_to_odeint``
        * ``mousai_to_solve_ivp``
-
     """
+
     def new_sdfunc(x, t, params):
         params['cur_time'] = t
         return function(x, params)
@@ -1017,8 +1023,8 @@ def mousai_to_solve_ivp(sdfunc, params):
        * ``function_to_mousai``
        * ``old_mousai_to_new_mousai``
        * ``mousai_to_odeint``
-
     """
+
     sig = inspect.signature(sdfunc)
 
     call_parameters = list(sig.parameters.keys())
@@ -1056,8 +1062,8 @@ def mousai_to_odeint(sdfunc, params):
        * ``function_to_mousai``
        * ``old_mousai_to_new_mousai``
        * ``mousai_to_solve_ivp``
-
     """
+
     sig = inspect.signature(sdfunc)
 
     call_parameters = list(sig.parameters.keys())

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -728,8 +728,7 @@ def duff_osc(x, v, params):
 
     omega = params['omega']
     t = params['cur_time']
-    acceleration = np.array([[-x - .1 * x**3. - 0.2 * v + np.sin(omega * t)]])
-    return acceleration
+    return np.array([[-x - .1 * x**3. - 0.2 * v + np.sin(omega * t)]])  # returns acceleration
 
 
 def time_history(t, x, num_time_points=200, realify=True):

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -267,8 +267,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 params['cur_time'] = time[i]  # loops
                 # Note that everything in params can be accessed within
                 # `function`.
-                accel_from_deriv[:, i] = params['function'](x[:, i], vel[:, i],
-                                                            params)[:, 0]
+                accel_from_deriv[:, i] = params['function'](x[:, i], vel[:, i], params)[:, 0]
             e = accel_from_deriv - accel
         elif eqform == 'first_order':
             vel_from_deriv = np.zeros_like(vel)
@@ -279,8 +278,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 params['cur_time'] = time[i]
                 # Note that everything in params can be accessed within
                 # `function`.
-                vel_from_deriv[:, i] =\
-                    params['function'](x[:, i], params)[:, 0]
+                vel_from_deriv[:, i] = params['function'](x[:, i], params)[:, 0]
 
             e = vel_from_deriv - vel
         else:
@@ -290,7 +288,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
     try:
         x = globals()[method](hb_err, x0, **kwargs)
-    except:
+    except Exception as exception:
         x = x0  # np.full([x0.shape[0],x0.shape[1]],np.nan)
         amps = np.full([x0.shape[0], ], np.nan)
         phases = np.full([x0.shape[0], ], np.nan)
@@ -302,7 +300,7 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         phases = np.angle(xhar[:, 1])
         e = hb_err(x)
 
-    if realify is True:
+    if realify:
         x = np.real(x)
     else:
         print('x was real')
@@ -464,8 +462,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
             x0 = np.zeros((num_variables, 1 + num_harmonics * 2))
             x0 = x0 + np.random.randn(*x0.shape)
         else:
-            print('Error: Must either define number of variables or initial\
-                  guess for x.')
+            print('Error: Must either define number of variables or initial guess for x.')
             return
     elif num_harmonics is None:
         num_harmonics = int((x0.shape[1] - 1) / 2)
@@ -487,7 +484,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
     params['n_har'] = num_harmonics
 
     X0 = fftp.rfft(x0)
-    if mask_constant is True:
+    if mask_constant:
         X0 = X0[:, 1:]
 
     params['mask_constant'] = mask_constant
@@ -555,7 +552,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         omega = params['omega']
         time = params['time']
         mask_constant = params['mask_constant']
-        if mask_constant is True:
+        if mask_constant:
             X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
 
         x = fftp.irfft(X)
@@ -577,8 +574,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
                 params['cur_time'] = time_e[i]  # loops
                 # Note that everything in params can be accessed within
                 # `function`.
-                accel_from_deriv[:, i] = params['function'](x[:, i], vel[:, i],
-                                                            params)[:, 0]
+                accel_from_deriv[:, i] = params['function'](x[:, i], vel[:, i], params)[:, 0]
             e = (accel_from_deriv - accel)  # /np.max(np.abs(accel))
 
             states = accel
@@ -611,7 +607,7 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
         e = condense_rfft(e_fft, num_harmonics)
 
-        if mask_constant is True:
+        if mask_constant:
             e = e[:, 1:]
 
         e = e / np.max(np.abs(states_fft_condensed))
@@ -620,28 +616,26 @@ def hb_freq(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
     try:
         X = globals()[method](hb_err, X0, **kwargs)
         e = hb_err(X)
-        if mask_constant is True:
+        if mask_constant:
             X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
-        amps = np.sqrt(X[:, 1]**2+X[:, 2]**2)*2/X.shape[1]
+        amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
         phases = np.arctan2(X[:, 1], -X[:, 2])
-    except:  # Catches and raises errors- needs actual error listed.
-        print(
-            'Excepted- search failed for omega = {:6.4f} rad/s.'.format(omega))
-        print("""What ever error this is, please put into har_bal
-               after the excepts (2 of them)""")
+    except Exception as exception:  # Catches and raises errors- needs actual error listed.
+        print('Excepted- search failed for omega = {:6.4f} rad/s.'.format(omega))
+        print('What ever error this is, please put into har_bal after the excepts (2 of them)')
         X = X0
         print(mask_constant)
         e = hb_err(X)
-        if mask_constant is True:
+        if mask_constant:
             X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
-        amps = np.sqrt(X[:, 1]**2+X[:, 2]**2)*2/X.shape[1]
+        amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
         phases = np.arctan2(X[:, 1], -X[:, 2])
 
         raise
 
     x = fftp.irfft(X)
 
-    if realify is True:
+    if realify:
         x = np.real(x)
     else:
         print('x was real')
@@ -792,7 +786,7 @@ def time_history(t, x, num_time_points=200, realify=True):
     x_freq = np.insert(x_freq, [t_length - t_length // 2], x_zeros, axis=1)
 
     x = fftp.ifft(x_freq) * num_time_points / t_length
-    if realify is True:
+    if realify:
         x = np.real(x)
     else:
         print('x was real')
@@ -895,7 +889,7 @@ def time_history_r(t, x, num_time_points=200, realify=True):
     # x_freq = np.hstack((x_freq, x_zeros))
     # print(x_freq)
     x = fftp.ifft(x_freq) * num_time_points / t_length
-    if realify is True:
+    if realify:
         x = np.real(x)
     else:
         print('x was real')
@@ -936,7 +930,6 @@ def function_to_mousai(sdfunc):
 
     .. _`odeint` : https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.ode.html#scipy.integrate.ode
     .. _`solve_ivp` : https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html#scipy.integrate.solve_ivp
-
     """
 
     sig = inspect.signature(sdfunc)

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -825,15 +825,13 @@ def expand_rfft(X, num_harmonics):
 def rfft_to_fft(X_real):
     """Switch from SciPy real fft form to complex fft form."""
 
-    X = fftp.fft(fftp.irfft(X_real))
-    return X
+    return fftp.fft(fftp.irfft(X_real))
 
 
 def fft_to_rfft(X):
     """Switch from complex form fft form to SciPy rfft form."""
 
-    X_real = fftp.rfft(np.real(fftp.ifft(X)))
-    return X_real
+    return fftp.rfft(np.real(fftp.ifft(X)))
 
 
 def time_history_r(t, x, num_time_points=200, realify=True):
@@ -892,6 +890,7 @@ def time_history_r(t, x, num_time_points=200, realify=True):
     # x_freq = np.hstack((x_freq, x_zeros))
     # print(x_freq)
     x = fftp.ifft(x_freq) * num_time_points / t_length
+
     if realify:
         x = np.real(x)
     else:
@@ -936,7 +935,6 @@ def function_to_mousai(sdfunc):
     """
 
     sig = inspect.signature(sdfunc)
-
     call_parameters = list(sig.parameters.keys())
 
     if len(call_parameters) == 2:
@@ -951,6 +949,7 @@ def function_to_mousai(sdfunc):
                 for k, v in params.items():
                     exec("%s = %s" % (k, v))
                 return sdfunc(x, t)
+
     else:
         if call_parameters[0] == 't' or call_parameters[0] == 'time':
             # t and x must be swapped, params available in over-scope
@@ -961,6 +960,7 @@ def function_to_mousai(sdfunc):
             def newfunction(x, t, params={}):
                 other_params = [params[x] for x in call_parameters]
                 return sdfunc(x, t, *other_params)
+
     return newfunction
 
 
@@ -994,6 +994,7 @@ def old_mousai_to_new_mousai(function):
     def new_sdfunc(x, t, params):
         params['cur_time'] = t
         return function(x, params)
+
     return new_sdfunc
 
 
@@ -1026,7 +1027,6 @@ def mousai_to_solve_ivp(sdfunc, params):
     """
 
     sig = inspect.signature(sdfunc)
-
     call_parameters = list(sig.parameters.keys())
 
     if len(call_parameters) == 2:
@@ -1064,7 +1064,6 @@ def mousai_to_odeint(sdfunc, params):
     """
 
     sig = inspect.signature(sdfunc)
-
     call_parameters = list(sig.parameters.keys())
 
     if len(call_parameters) == 2:

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -795,8 +795,12 @@ def time_history(t, x, num_time_points=200, realify=True):
 def condense_fft(X_full, num_harmonics):
     """Create equivalent amplitude reduced-size FFT from longer FFT."""
 
-    X_red = (np.hstack((X_full[:, 0:(num_harmonics + 1)], X_full[:, -1:-(num_harmonics + 1):-1])) * (2 * num_harmonics + 1) / X_full[0, :].size)
-    return X_red
+    # TODO: rename these variables. Were pulled from last line of code. This function was one line of code. Vars pulled out for readability
+    x_full_0 = X_full[:, 0:(num_harmonics + 1)]
+    x_full_1 = X_full[:, -1:-(num_harmonics + 1):-1]
+    hstack = np.hstack((x_full_0, x_full_1)) * (2 * num_harmonics + 1)
+
+    return (hstack / X_full[0, :].size)
 
 
 def condense_rfft(X_full, num_harmonics):

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -168,8 +168,10 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
         else:
             print('Error: Must either define number of variables or initial guess for x.')
             return
+
     elif num_harmonics is None:
         num_harmonics = int((x0.shape[1] - 1) / 2)
+
     elif 1 + 2 * num_harmonics > x0.shape[1]:
         x_freq = fftp.fft(x0)
         x_zeros = np.zeros((x0.shape[0], 1 + num_harmonics * 2 - x0.shape[1]))
@@ -177,9 +179,11 @@ def hb_time(sdfunc, x0=None, omega=1, method='newton_krylov', num_harmonics=1,
 
         x0 = fftp.ifft(x_freq) * (1 + num_harmonics * 2) / x0.shape[1]
         x0 = np.real(x0)
+
     if isinstance(sdfunc, str):
         sdfunc = globals()[sdfunc]
         print('sdfunc is expected to be a function name, not a string')
+
     params['function'] = sdfunc  # function that returns SO derivative
     time = np.linspace(0, 2 * np.pi / omega, num=x0.shape[1], endpoint=False)
     params['time'] = time

--- a/mousai/har_bal.py
+++ b/mousai/har_bal.py
@@ -807,8 +807,8 @@ def condense_rfft(X_full, num_harmonics):
     """Return real fft with fewer harmonics."""
 
     X_len = X_full.shape[1]
-    X_red = X_full[:, :(num_harmonics) * 2 + 1] / X_len * (1 + 2 * num_harmonics)
-    return X_red
+    x_full = X_full[:, :(num_harmonics) * 2 + 1]  # TODO: rename var. Was pulled from below line to improve readability
+    return x_full / X_len * (1 + 2 * num_harmonics)
 
 
 def expand_rfft(X, num_harmonics):


### PR DESCRIPTION
## Changes

Many changes were done to improve readability, including, but not limited to, the following:

- Newlines added to separate logical blocks of code
- Newlines removed to bring lines together into logical blocks of code
- `if x is True` changed to `if x`
- Docstring endings standardized to visibly separate code from documentation
- Print statement quotes standardized to `'` (was using `"` and `"""` in some places)
- Added blanket excepts to empty except blocks
- Single line functions broken into multiple lines for readability

## Questions for Maintainers

### Line 292 Try/Except

```py
    try:
        x = globals()[method](hb_err, x0, **kwargs)

    except Exception as exception:
        x = x0  # np.full([x0.shape[0],x0.shape[1]],np.nan)
        amps = np.full([x0.shape[0], ], np.nan)
        phases = np.full([x0.shape[0], ], np.nan)
        e = hb_err(x)  # np.full([x0.shape[0],x0.shape[1]],np.nan)
        raise
```

Raising an exception terminates the code. Why is there code in the except block if it will do nothing? The `raise` statement should pass a string to be in the exception message. This provides no insight as to why the code failed.

### Line 615 Try/Except

```py
    try:
        X = globals()[method](hb_err, X0, **kwargs)
        e = hb_err(X)
        if mask_constant:
            X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
        amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
        phases = np.arctan2(X[:, 1], -X[:, 2])

    except Exception as exception:  # Catches and raises errors- needs actual error listed.
        print('Excepted- search failed for omega = {:6.4f} rad/s.'.format(omega))
        print('Whatever error this is, please put into har_bal after the excepts (2 of them)')
        X = X0
        print(mask_constant)
        e = hb_err(X)
        if mask_constant:
            X = np.hstack((np.zeros_like(X[:, 0]).reshape(-1, 1), X))
        amps = np.sqrt(X[:, 1] ** 2 + X[:, 2] ** 2) * 2 / X.shape[1]
        phases = np.arctan2(X[:, 1], -X[:, 2])
        raise
```

Very much the same as the above question. This prints some information that could be put in the `raise` statement, but is not.

## Requests for Maintainers

### New Docstrings

The docstrings on the following functions are very weak and do not provide any useful insight into what the function does or how it works. Users are left to interpret what was originally a much messier single line of code.

- `duff_osc()`
- `condense_fft()`
- `condense_rfft()`
- `expand_rfft()`

### New Variable Names in Specific Functions

The following functions were originally one line, but now are broken into multiple so as to be more readable. Single line functions are generally a bad idea, especially these, as their complexity makes them hard to read.

- `condense_fft()`
- `condense_rfft()`
- `expand_rfft()`

### New Variable Names

All code in this repository suffers from the same issue. The code was clearly written by a trained mathematician who knows how to program, and not a trained programmer who knows math. Variables such as `x`, `e`, `x`, `m`, `x0`, etc, are used extensively throughout the code. While these variables may translate nicely to math, unless those names are standardized across all applications of that math and every potential user is painfully familiar with them, names such as these hurt the readability of the code. Variable names should be descriptive and tell the user what they hold. For example, `x` is a valid name when doing an embarrassingly simple task, such as adding two values. However, if those two values have any sort of context associated with them, `x` is much better off being named after that context. When the context is complex, such as in this program, it is even more important to provide useful variable names so someone unfamiliar with the code can read and learn the algorithm. Code that can only be read by the author can only be maintained by the author.

## Other Notes

Had I not been specifically requested by the author to review and format this code, I would not have done so. While I strongly believe in the majority of PEP, I believe that it is most important that the author of the code, and no one else, "PEP-ify" their code. There is a [PyCon presentation by Raymond Hettinger](https://www.youtube.com/watch?v=wf-BqAjZb8M) that goes into this in depth. I highly recommend watching. There is a _very_ strong chance that in making this code more readable, I broke something without realizing it. This should be expected, as I am unfamiliar with the code. However, without formatting the code first, anyone would find it hard to understand. For this reason I strongly emphasize that **THIS PULL REQUEST SHOULD NOT BE MERGED WITHOUT EXTENSIVE TESTING AND REVIEW BY THE AUTHOR**.